### PR TITLE
Update Migrations.sol

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -15,9 +15,4 @@ contract Migrations {
   function setCompleted(uint completed) public restricted {
     last_completed_migration = completed;
   }
-
-  function upgrade(address new_address) public restricted {
-    Migrations upgraded = Migrations(new_address);
-    upgraded.setCompleted(last_completed_migration);
-  }
 }


### PR DESCRIPTION
Remove unused `upgrade` function from `Migrations.sol`.

A quick Google-fu query reveals that there is no OSS project using the method in deployment or test scripts.

It appears this never worked as intended: trufflesuite/truffle#216.

Lowers the migration cost for users who actually use the current migrations system for deployments & testing.