### PR TITLE
Update to Vyper version 0.2.11

### DIFF
--- a/contracts/VyperStorage.vy
+++ b/contracts/VyperStorage.vy
@@ -1,10 +1,10 @@
 stored_data: uint256
 
-@public
+@external
 def set(new_value : uint256):
     self.stored_data = new_value
 
-@public
-@constant
+@external
+@view
 def get() -> uint256:
     return self.stored_data


### PR DESCRIPTION
The old code with `@public` and `@constant` doesn't compile, they don't exist in the current version of the language (see https://vyper.readthedocs.io/en/latest/control-structures.html#function-visibility).